### PR TITLE
use correct single header catch version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,7 @@ echo "Linking examples"
 g++ -o examples shapes.o test.o examples.o
 
 echo "Building tests"
-g++ -c -o unittest.o ut/unittest.cc -I./ -ICatch2/extras/
-g++ -c -o catch.o Catch2/extras/catch_amalgamated.cpp -ICatch2/extras/
+g++ -c -o unittest.o ut/unittest.cc -I./ -ICatch2/single_include/catch2/
 
 echo "Linking tests"
-g++ -o unittest catch.o unittest.o shapes.o command.o
+g++ -o unittest unittest.o shapes.o command.o

--- a/ut/unittest.cc
+++ b/ut/unittest.cc
@@ -1,7 +1,9 @@
+#define CATCH_CONFIG_MAIN
+
 #include "shapes.hh"
 #include "command.hh"
 
-#include "catch_amalgamated.hpp"
+#include "catch.hpp"
 
 TEST_CASE("Simple command test")
 {


### PR DESCRIPTION
Use a correct way to build and run test - single header file option : 
https://github.com/catchorg/Catch2/blob/ca455815fdbe7774ef81fed497f0026cd5bc3965/docs/tutorial.md#where-to-put-it