### PR TITLE
SHPDR-28 add build and unittest github actions pipeline

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,21 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: make
+      run: make
+    - name: unittest
+      run: ./unittest


### PR DESCRIPTION
with this it would be possible to automatically build and run unittest when creating pull request or pushing to main branch.
The github actions do the following:
* make
* ./unittest